### PR TITLE
updates and type fixes for the milkweed mason pages

### DIFF
--- a/mason/about/sgn/index.mas
+++ b/mason/about/sgn/index.mas
@@ -1,10 +1,6 @@
 
-<h3>About MusaBase</h3>
+<h3>About MilkweedBase</h3>
 
-<div class="boxcontent">MusaBase is a breeding database designed for advanced breeding methods in banana breeding. It focuses on bananas that are important food crops in Africa, such as Mchare and Matooke bananas.</div>
+<div class="boxcontent">MilkweedBase is a database designed for making data available and advancing research in the milkweed genus, <i>Asclepias</i>.</div>
 
-<div class="boxcontent">Data in MusaBase comes mainly from breeding programs in Uganda (NARO Kawanda, IITA Sendusu) as well as Tanzania (IITA Arusha, newly located at Nelson Mandela University).</div>
-
-<div class="boxcontent">If you are interested in submitting your breeding trial or genotyping data to MusaBase, please <a href="/contact/form">contact us</a>.</div>
-
-<div class="boxcontent">Note that data on MusaBase are associated with Data Agreements and that they are not necessarily in the public domain. Please contact the authors of the data if you are interested in any aspect of data production or analysis.</div>
+<div class="boxcontent">If you are interested in submitting your data to MilkweedBase, please <a href="/contact/form">contact us</a>.</div>

--- a/mason/help/faq.mas
+++ b/mason/help/faq.mas
@@ -1,4 +1,4 @@
-<& "/page/page_title.mas", title => "Cassavabase: Frequently Asked Questions (FAQ)" &>
+<& "/page/page_title.mas", title => "MilkweedBase: Frequently Asked Questions (FAQ)" &>
 <table summary="" width="720" cellpadding="0" cellspacing="0"
   border="0">
     <tr>
@@ -8,23 +8,23 @@
           cellspacing="0" border="0">
             <tr>
               <td>
-                This page contains questions that Cassavabase users ask and
-                are useful to the larger cassava community. Please
+                This page contains questions that MilkweedBase users ask and
+                are useful to the larger milkweed community. Please
                 <a href="mailto:sgn-feedback\@sgn.cornell.edu">let
                 us know</a> if you have a question that you think
                 should be added.
 
 
-                <p><strong>Question:</strong> The CassavaBase pages look really
+                <p><strong>Question:</strong> The MilkweedBase pages look really
                 messed up on my browser.<br />
                 <strong>Answer:</strong> You are working with an old browser
                 that does not support style sheets, such as the
-                browsers of the Netscape 4.x series. CassavaBase pages
+                browsers of the Netscape 4.x series. MilkweedBase pages
                 require style sheets and javascript to be turned
                 on.</p>
 
                 <p><strong>Question:</strong> Can I submit my data to
-                CassavaBase?<br />
+                MilkweedBase?<br />
                 <strong>Answer:</strong> Please send an email to <a href=
                 "mailto:sgn-feedback\@sgn.cornell.edu">sgn-feedback@sgn.cornell.edu</a>
                 with a description of the data you would like to

--- a/mason/help/index.mas
+++ b/mason/help/index.mas
@@ -4,7 +4,7 @@
 
 <h3>Manual</h3>
 
-<div>The MilkweedBase manual is available as a <a href="https://solgenomics.github.io/sgn/">Google Doc</a>. It was written for CassavaBase but MilkweedBase is based on CassavaBase, so the manual applies to MilkweedBase as well, although MilkweedBase only implments a small subset of the Cassavabase features.</div>
+<div>The MilkweedBase manual is available as a <a href="https://solgenomics.github.io/sgn/">Google Doc</a>. It was written for CassavaBase but MilkweedBase is based on CassavaBase, so the manual applies to MilkweedBase as well, although MilkweedBase only implements a small subset of the Cassavabase features.</div>
 
 <h3>FAQ</h3>
 


### PR DESCRIPTION
Changing some of the placeholder text, so that it now refers to milkweedbase instead of other bases